### PR TITLE
build: include boto folder in shared data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ exclude = [".github", "binder"]
 [tool.hatch.build.targets.wheel.shared-data]
 "amazon_codeguru_jupyterlab_extension/labextension" = "share/jupyter/labextensions/@aws/amazon-codeguru-extension"
 "install.json" = "share/jupyter/labextensions/@aws/amazon-codeguru-extension/install.json"
+"configuration/boto" = "boto"
 
 [tool.hatch.build.hooks.version]
 path = "amazon_codeguru_jupyterlab_extension/_version.py"


### PR DESCRIPTION
Include `boto` folder with `pip install` command. 