### PR TITLE
fix: show error message in popup when scan fails

### DIFF
--- a/src/components/CodeScanStatus.tsx
+++ b/src/components/CodeScanStatus.tsx
@@ -51,9 +51,11 @@ function CodeScanStatusComponent(props: ICodeScanStatusComponent): JSX.Element {
           ? 'CodeGuru: Missing credentials'
           : 'CodeGuru: Scan failed';
       return (
-        <StatusIndicator type="warning">
-          <TextItem source={title} />
-        </StatusIndicator>
+        <div onClick={() => props.handleClick(errorType)}>
+          <StatusIndicator type="warning">
+            <TextItem source={title} />
+          </StatusIndicator>
+        </div>
       );
     }
     case 'completed': {


### PR DESCRIPTION
When scan fails due to missing configuration or incorrect credentials, the scan fails. We showing a popup modal to handle the failing scenario. Added logic to show popup in these scenarios. 