### PR TITLE
feat: updated scan name

### DIFF
--- a/amazon_codeguru_jupyterlab_extension/diagnostics.py
+++ b/amazon_codeguru_jupyterlab_extension/diagnostics.py
@@ -175,7 +175,7 @@ def get_message_for_finding(finding, py_filepath, is_nb_file):
     }
 
 
-def get_diagnostics(workspace: Workspace, document: Document, overridden_region: str):
+def get_diagnostics(workspace: Workspace, document: Document, overridden_region: str, platform: str):
     codeguru_security = get_codeguru_security_client(overridden_region)
 
     with workspace.report_progress("command: runScan") as send_notification:
@@ -185,8 +185,10 @@ def get_diagnostics(workspace: Workspace, document: Document, overridden_region:
         py_filepath = create_python_from_notebook(
             path_to_nb) if is_nb_file else document.path
         zip_filepath = create_zip_from_python(py_filepath)
-        scan_name = "{}-{}".format(os.path.basename(zip_filepath),
-                                   datetime.now().isoformat())
+        scan_name = "{}-{}-{}".format(platform, os.path.basename(zip_filepath),
+                                      datetime.now().isoformat())
+        # truncating scan name to avoid scan failure due to scan name character limit
+        scan_name = scan_name[:140]
         code_artifact_id = upload_file(
             zip_filepath, scan_name, codeguru_security, send_notification)
         run_id = create_scan(code_artifact_id, scan_name,

--- a/amazon_codeguru_jupyterlab_extension/plugin.py
+++ b/amazon_codeguru_jupyterlab_extension/plugin.py
@@ -35,8 +35,10 @@ def pylsp_execute_command(config: Config, workspace: Workspace, command: str, ar
     if command == "cgs.runScan":
         doc_uri = arguments[0]
         overridden_region = arguments[1]
+        platform = arguments[2]
         document = workspace.get_document(doc_uri)
-        execute_run_scan(config, workspace, document, overridden_region)
+        execute_run_scan(config, workspace, document,
+                         overridden_region, platform)
 
 
 @hookimpl
@@ -44,7 +46,10 @@ def pylsp_lint(config: Config, workspace: Workspace, document: Document, is_save
     return cfg.diagnostics_by_document.get(document.uri)
 
 
-def execute_run_scan(config: Config, workspace: Workspace, document: Document, overridden_region: str):
-    other_diagnostics = get_diagnostics_from_other_sources(config, workspace, document)
-    cfg.diagnostics_by_document[document.uri] = get_diagnostics(workspace, document, overridden_region)
-    workspace.publish_diagnostics(doc_uri=document.uri, diagnostics=other_diagnostics + cfg.diagnostics_by_document.get(document.uri))
+def execute_run_scan(config: Config, workspace: Workspace, document: Document, overridden_region: str, platform: str):
+    other_diagnostics = get_diagnostics_from_other_sources(
+        config, workspace, document)
+    cfg.diagnostics_by_document[document.uri] = get_diagnostics(
+        workspace, document, overridden_region, platform)
+    workspace.publish_diagnostics(
+        doc_uri=document.uri, diagnostics=other_diagnostics + cfg.diagnostics_by_document.get(document.uri))

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY
 from amazon_codeguru_jupyterlab_extension import plugin
 from tests.conftest import *
 
+
 def test_settings():
     result = plugin.pylsp_settings()
     expected = {
@@ -33,23 +34,30 @@ def test_lint_without_existing_diagnostics(config, workspace, document):
 
 
 def test_execute_run_scan(config, workspace, document):
-    plugin.get_diagnostics_from_other_sources = Mock(return_value=[{"message": "1"}])
+    plugin.get_diagnostics_from_other_sources = Mock(
+        return_value=[{"message": "1"}])
     plugin.get_diagnostics = Mock(return_value=[{"message": "2"}])
     plugin.Workspace.publish_diagnostics = Mock()
-    plugin.execute_run_scan(config, workspace, document, "region")
-    plugin.get_diagnostics_from_other_sources.assert_called_once_with(config, workspace, document)
-    plugin.get_diagnostics.assert_called_once_with(workspace, document, "region")
-    plugin.Workspace.publish_diagnostics.assert_called_once_with(doc_uri=document.uri, diagnostics=[{"message": "1"}, {"message": "2"}])
+    plugin.execute_run_scan(config, workspace, document, "region", "jl")
+    plugin.get_diagnostics_from_other_sources.assert_called_once_with(
+        config, workspace, document)
+    plugin.get_diagnostics.assert_called_once_with(
+        workspace, document, "region", "jl")
+    plugin.Workspace.publish_diagnostics.assert_called_once_with(
+        doc_uri=document.uri, diagnostics=[{"message": "1"}, {"message": "2"}])
 
 
 def test_execute_command_run_scan(config, workspace, document):
     plugin.execute_run_scan = Mock()
     workspace.get_document = Mock(return_value=document)
-    plugin.pylsp_execute_command(config, workspace, "cgs.runScan", [document.uri, "region"])
-    plugin.execute_run_scan.assert_called_once_with(config, workspace, document, "region")
+    plugin.pylsp_execute_command(config, workspace, "cgs.runScan", [
+                                 document.uri, "region", "jl"])
+    plugin.execute_run_scan.assert_called_once_with(
+        config, workspace, document, "region", "jl")
 
 
 def test_execute_command_other(config, workspace):
     plugin.execute_run_scan = Mock()
-    plugin.pylsp_execute_command(config, workspace, "some-cmd", ["some", "args"])
+    plugin.pylsp_execute_command(
+        config, workspace, "some-cmd", ["some", "args"])
     assert not plugin.execute_run_scan.called


### PR DESCRIPTION
*Issue #, if available:*
Identifying the source of scan is difficult for the plugin.

*Description of changes:*
Added prefix for scan name to distinguish requests from SageMaker and JupyterLab

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
